### PR TITLE
终端中输出二维码，直接用手机扫码

### DIFF
--- a/jd_assistant.py
+++ b/jd_assistant.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from cgitb import small
 import json
 import os
 import pickle
 import re
 import random
 import time
-from turtle import width
-import qrcode_terminal
 
+import qrcode_terminal
 from qrdecode import *
 
 import requests
@@ -41,8 +39,6 @@ from util import (
     split_area_id
 )
 
-import urllib3
-urllib3.disable_warnings()
 
 class Assistant(object):
 
@@ -160,7 +156,7 @@ class Assistant(object):
 
     def _get_login_page(self):
         url = "https://passport.jd.com/new/login.aspx"
-        page = self.sess.get(url, headers=self.headers, verify=False)
+        page = self.sess.get(url, headers=self.headers)
         return page
 
     @deprecated
@@ -233,24 +229,7 @@ class Assistant(object):
         return True
 
     
-
-    # """ 读取二维码的内容： img_adds：二维码地址（可以是网址也可是本地地址 """
-        if os.path.isfile(img_adds):
-            # 从本地加载二维码图片
-            img = Image.open(img_adds)
-        else:
-            # 从网络下载并加载二维码图片
-            rq_img = requests.get(img_adds).content
-            img = Image.open(BytesIO(rq_img))
-
-        # img.show()  # 显示图片，测试用
-
-        txt_list = pyzbar.decode(img)       
-
-        for txt in txt_list:
-            barcodeData = txt.data.decode("utf-8")
-            print(barcodeData)
-            return barcodeData
+  
             
     @deprecated            
     def _get_login_result(self, resp):
@@ -303,7 +282,7 @@ class Assistant(object):
         txt_list = decode(QRCode_file)       
             
        
-        qrcode_terminal.draw(txt_list,{ small: True })
+        qrcode_terminal.draw(txt_list,3)
         
         return True
 

--- a/qrdecode.py
+++ b/qrdecode.py
@@ -1,0 +1,32 @@
+import os
+import requests
+from io import BytesIO
+from pyzbar import pyzbar
+from PIL import Image,ImageEnhance
+ 
+ 
+def decode(img_adds):
+    """ 读取二维码的内容： img_adds：二维码地址（可以是网址也可是本地地址 """
+    if os.path.isfile(img_adds):
+        # 从本地加载二维码图片
+        img = Image.open(img_adds)
+    else:
+        # 从网络下载并加载二维码图片
+        rq_img = requests.get(img_adds).content
+        img = Image.open(BytesIO(rq_img))
+ 
+    # img.show()  # 显示图片，测试用
+ 
+    txt_list = pyzbar.decode(img)
+ 
+    for txt in txt_list:
+        barcodeData = txt.data.decode("utf-8")
+        print(barcodeData)
+        return txt_list
+ 
+# if __name__ == '__main__':
+#     # 解析本地二维码
+#     get_ewm('QRcode.png')
+ 
+#     # 解析网络二维码
+#     get_ewm('https://gqrcode.alicdn.com/img?type=cs&shop_id=445653319&seller_id=3035998964&w=140&h=140&el=q&v=1')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.20.0
 pycryptodome==3.6.6
 pandas==1.3.2
 openpyxl==3.0.7
+qrcode_terminal>=0.8


### PR DESCRIPTION
将输出的二维图片转成文本（这步貌似可以省略）

将文本转成二维码输出在终端中，直接用手机扫码，不需要打开看图软件。


直接将图片输出在终端中，会丢失信息，导致扫码不成功。

终端二维码，显示异常的，需要调整终端字体缩放。